### PR TITLE
make keylength a command line parameter for generate-keypair.js. issue #3

### DIFF
--- a/generate-keypair.js
+++ b/generate-keypair.js
@@ -7,7 +7,25 @@
 var jwk = require("./jwk"),
     fs = require("fs");
 
-var keypair = jwk.KeyPair.generate("RS",128);
+var args = require('optimist')
+.usage('Generate an RSA keypair.\nUsage: $0', [ "foo" ])
+.alias('h', 'help')
+.describe('h', 'display this usage message')
+.alias('k', 'keylength')
+.describe('k', 'keylength, one of 64, 128, or 256.')
+.default('k', 128);
+var argv = args.argv;
+
+if (argv.h) {
+  args.showHelp();
+  process.exit(1);
+} else if (-1 === [ 64, 128, 256 ].indexOf(argv.k)) {
+  console.log("invalid keylength:", argv.k);
+  process.exit(1);
+}
+
+
+var keypair = jwk.KeyPair.generate("RS", argv.k);
 
 fs.writeFileSync("key.publickey", keypair.publicKey.serialize());
 fs.writeFileSync("key.secretkey", keypair.secretKey.serialize());

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   , "version": "0.0.1"
   , "dependencies": {
     "browserify": "1.5.0",
-    "vows": "0.5.11"
+    "vows": "0.5.11",
+    "optimist": "0.2.6"
   }
   , "scripts": {
     "postinstall": "./bundle.sh",


### PR DESCRIPTION
make keylength a command line parameter for generate-keypair.js. closes #3

By doing this we don't have to change this repository every time we want to change the key length in repositories that depend on it (like browserid!).
