### PR TITLE
Copy InputException from jws.js

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -35,6 +35,11 @@
 
 var libs = require("./libs/all");
 
+function InputException(message) {
+  this.message = message;
+  this.toString = function() { return "Malformed input: "+this.message; };
+}
+
 // patch the window object;
 if (typeof(window) === "undefined")
   var window = libs.window;


### PR DESCRIPTION
This is used in the utils.base64urldecode() function but not
defined there.

Because of this, the vep.unbundleCertsAndAssertion() function (used
in the BrowserID verifier) returns this exception message:

  ReferenceError: InputException is not defined

instead of:

  Malformed input: Illegal base64url string!
