### PR TITLE
Replace the use of "const" with "var".  const causes IE to throw an exception.

### DIFF
--- a/lib/assertion.js
+++ b/lib/assertion.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const jwcrypto = require("./jwcrypto"),
+var jwcrypto = require("./jwcrypto"),
       utils = require("./utils");
 
 function serializeAssertionParamsInto(assertionParams, params) {
@@ -23,7 +23,7 @@ function extractAssertionParamsFrom(params) {
   delete params.iat;
   delete params.exp;
   delete params.iss;
-  delete params.aud;  
+  delete params.aud;
   return assertionParams;
 };
 


### PR DESCRIPTION
issue #15
