### PR TITLE
Fixing wrong default for duration

### DIFF
--- a/bin/certify
+++ b/bin/certify
@@ -24,7 +24,7 @@ var args = require('optimist')
 .demand('s')
 .alias('d', 'duration')
 .describe('d', 'duration of certificate in seconds')
-.default('s', 365 * 24 * 60 * 60);
+.default('d', 365 * 24 * 60 * 60);
 
 var argv = args.argv;
 


### PR DESCRIPTION
Default duration of 31536000 was being set on secret instead of duration.
