### PR TITLE
Fixing check-cert algorithms, adding CLI arguments support

### DIFF
--- a/bin/check-cert.js
+++ b/bin/check-cert.js
@@ -52,7 +52,7 @@ if (debug) console.log(JSON.stringify(JSON.parse(pk.serialize()), null, 4));
 
 console.log("verifying the raw signature - no cert specific verification");
 
-jwcrypto.verify(cert, pk, function(err, payload) {
+jwcrypto.verify(cert_raw, pk, function(err, payload) {
   if (err) {
     console.log("doesn't work");
     console.log(err);


### PR DESCRIPTION
I was unable to run `bin/check-cert` against a newly generated chained cert.

I found the ergonomics of using certs and public keys directly in the CLI challenging.

This PR does a couple things:
1) require DS and RS modules
2) Add optimist and

```
Check certificate
Usage: node ./bin/check-cert.js

Options:
  -p, --public       public key to sign                               [required]
  -h, --help         display this usage message                     
  -c, --certificate  A certificate which you want to examine.         [required]
  -d, --debug        Debug mode, useful for development of this tool  [boolean]  [default: false]
```

3) Minor style cleanup
