### PR TITLE
check-cert tries to verify a cert object, instead of a string.

### DIFF
--- a/bin/check-cert.js
+++ b/bin/check-cert.js
@@ -16,7 +16,7 @@ var pk = jwcrypto.loadPublicKey(pk_raw);
 
 console.log("verifying the raw signature - no cert specific verification");
 
-jwcrypto.verify(cert, pk, function(err, payload) {
+jwcrypto.verify(cert_raw, pk, function(err, payload) {
   if (err) {
     console.log("doesn't work");
     console.log(err);


### PR DESCRIPTION
Simple fix, use raw cert, instead of cert object. Fixes check-cert.
