### PR TITLE
Fixing typo in test issuser -> issuer

### DIFF
--- a/test/cert-test.js
+++ b/test/cert-test.js
@@ -112,7 +112,7 @@ testUtils.addBatches(suite, function(alg, keysize) {
                         {issuer: "root.com", issuedAt: new Date(), expiresAt: expiration}, null,
                         root_kp.secretKey, function (err, signedIntermediate) {
                           cert.sign(user_kp.publicKey, {email: "john@root.com"},
-                                    {issuser: "intermediate.root.com", issuedAt: new Date(), expiresAt: expiration},
+                                    {issuer: "intermediate.root.com", issuedAt: new Date(), expiresAt: expiration},
                                     null, intermediate_kp.secretKey,
                                     function(err, signedUser) {
                                       signAssertion(root_kp.publicKey,


### PR DESCRIPTION
The issuer field of the intermediary was misspelled.

Aside:
Either this is not critical for cert chaining, or the test isn't extensive enough to fail, since issuer was null.
