### PR TITLE
Invalid const

### DIFF
--- a/lib/algs/rs.js
+++ b/lib/algs/rs.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const libs = require("../../libs/all"),
+var   libs = require("../../libs/all"),
       algs = require("./index"),
    version = require("../version"),
 BigInteger = libs.BigInteger;
@@ -68,7 +68,7 @@ PublicKey.prototype.verify = function(message, signature, cb) {
 
 PublicKey.prototype._LEGACY_serializeToObject = function(obj) {
   obj.n = this.rsa.n.toString();
-  obj.e = this.rsa.e.toString();  
+  obj.e = this.rsa.e.toString();
 };
 
 PublicKey.prototype._20120815_serializeToObject = function(obj) {
@@ -82,7 +82,7 @@ PublicKey.prototype.serializeToObject = version.versionDispatcher('serializeToOb
 PublicKey.prototype.equals = function(other) {
   if (other == null)
     return false;
-  
+
   // FIXME: this is loser-ville if e is not an integer
   return ((this.rsa.n.equals(other.rsa.n)) && (this.rsa.e == other.rsa.e || this.rsa.e.equals(other.rsa.e)) && (this.algorithm == other.algorithm));
 };
@@ -101,7 +101,7 @@ PublicKey.prototype.deserializeFromObject = function(obj) {
   this.rsa = new libs.RSAKey();
 
   version.dispatchOnDataFormatVersion(this, 'deserializeFromObject', obj.version, obj);
-  
+
   this.keysize = _getKeySizeFromRSAKeySize(this.rsa.n.bitLength());
   return this;
 };
@@ -161,10 +161,10 @@ SecretKey.prototype.deserializeFromObject = function(obj) {
   version.dispatchOnDataFormatVersion(this, 'deserializeFromObject', obj.version, obj);
 
   this.keysize = _getKeySizeFromRSAKeySize(this.rsa.n.bitLength());
-  return this;  
+  return this;
 };
 
-// register this stuff 
+// register this stuff
 algs.register("RS", {
   generate: generate,
   PublicKey: PublicKey,

--- a/lib/version.js
+++ b/lib/version.js
@@ -5,19 +5,19 @@
 // tracking the version number in a separate location so we
 // don't have circular dependencies.
 
-const SUPPORTED_DATA_FORMATS = ['2012.08.15', ''];
+var SUPPORTED_DATA_FORMATS = ['2012.08.15', ''];
 
 // XXX - upgrade this to 2012.08.15 when we're ready
-const DEFAULT_DATA_FORMAT_VERSION = '';
+var DEFAULT_DATA_FORMAT_VERSION = '';
 var DATA_FORMAT_VERSION = DEFAULT_DATA_FORMAT_VERSION;
 
 exports.setDataFormatVersion = function(version) {
   if (version == undefined)
     version = DEFAULT_DATA_FORMAT_VERSION;
-  
+
   if (SUPPORTED_DATA_FORMATS.indexOf(version) == -1)
     throw new Error("no such version " + version + ", only supported versions are " + SUPPORTED_DATA_FORMATS.join(","));
-  
+
   DATA_FORMAT_VERSION = version;
 };
 


### PR DESCRIPTION
IE8 breaks wherever const is used.  Removing all instances of const and replacing with var.
