### PR TITLE
Adding protocol field

### DIFF
--- a/lib/assertion.js
+++ b/lib/assertion.js
@@ -14,6 +14,13 @@ SERIALIZER._LEGACY_serializeAssertionParamsInto = function(assertionParams, para
   params.exp = assertionParams.expiresAt ? assertionParams.expiresAt.valueOf() : undefined;
   params.iss = assertionParams.issuer;
   params.aud = assertionParams.audience;
+  // null is allowed, signals that identity is not SMTP routable
+  if (assertionParams.protocol === null ||
+      assertionParams.protocol) {
+    params.protocol = assertionParams.protocol;
+  } else {
+    params.protocol = 'SMTP';
+  }
 };
 
 SERIALIZER._20120815_serializeAssertionParamsInto = function(assertionParams, params) {
@@ -37,11 +44,13 @@ SERIALIZER._LEGACY_extractAssertionParamsFrom = function(params) {
   assertionParams.expiresAt = utils.getDate(params.exp);
   assertionParams.issuer = params.iss;
   assertionParams.audience = params.aud;
+  assertionParams.protocol = params.protocol;
 
   delete params.iat;
   delete params.exp;
   delete params.iss;
   delete params.aud;
+  delete params.protocol;
 
   return assertionParams;
 };


### PR DESCRIPTION
This sketches out adding protocol.

npm test fails (but it failed for me before I added this patch).

Defaults to 'SMTP', not sure if that is right.
Not sure if extracting this should be conditional.
