### PR TITLE
Fixing public key property

### DIFF
--- a/bin/check-assertion
+++ b/bin/check-assertion
@@ -162,7 +162,7 @@ extractAssertion(full_assertion, function (err, raw_assertion, full_assertion) {
           pk = jwcrypto.loadPublicKey(JSON.stringify(components.payload['public-key']));
         } else {
           console.log("cert is properly signed");
-          pk = certParams['public-key'];
+          pk = certParams['publicKey'];
         }
         if (typeof components.payload.iat !== 'number')
           console.log("FATAL: cert lacks an 'issued at' (.iat) field");


### PR DESCRIPTION
I've found a bug with check-assertions. It was saying an assertion had a malformed signature, when really the script used the wrong key for the public key.

This was discovered while troubleshooting https://github.com/mozilla/browserid/issues/2205
