### PR TITLE
add shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,75 @@
+{
+  "name": "jwcrypto",
+  "version": "0.4.1",
+  "dependencies": {
+    "browserify": {
+      "version": "1.13.5",
+      "dependencies": {
+        "detective": {
+          "version": "0.1.1",
+          "dependencies": {
+            "uglify-js": {
+              "version": "1.2.6"
+            }
+          }
+        },
+        "deputy": {
+          "version": "0.0.2",
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.3.3"
+            }
+          }
+        },
+        "resolve": {
+          "version": "0.2.2"
+        },
+        "nub": {
+          "version": "0.0.0"
+        },
+        "commondir": {
+          "version": "0.0.1"
+        },
+        "coffee-script": {
+          "version": "1.3.3"
+        },
+        "optimist": {
+          "version": "0.3.4",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2"
+            }
+          }
+        },
+        "http-browserify": {
+          "version": "0.1.1"
+        },
+        "vm-browserify": {
+          "version": "0.0.1"
+        },
+        "crypto-browserify": {
+          "version": "0.1.0"
+        }
+      }
+    },
+    "vows": {
+      "version": "0.5.13",
+      "dependencies": {
+        "eyes": {
+          "version": "0.1.7"
+        }
+      }
+    },
+    "optimist": {
+      "version": "0.2.6",
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2"
+        }
+      }
+    },
+    "uglify-js": {
+      "version": "1.0.6"
+    }
+  }
+}


### PR DESCRIPTION
browserify has loose dependencies, and that broke us, since
a newer version requires node 0.8. now we are in control.
