### PR TITLE
Include ./lib/algs/rs in bundle.js

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -31,4 +31,5 @@
 
 var jwcrypto = require("./lib/jwcrypto");
 require("./lib/algs/ds");
+require("./lib/algs/rs");
 


### PR DESCRIPTION
Because MockMyID needs to be able to manipulate RS keys, it can't use the normal `bidbundle.js` generated by `bundle.sh`.

This change includes `./lib/algs/rs` in the generated `bidbundle.js`
