### PR TITLE
Add clock skew tolerance for assertions. Fixes Issue#58

### DIFF
--- a/lib/assertion.js
+++ b/lib/assertion.js
@@ -25,7 +25,7 @@ SERIALIZER._20120815_serializeAssertionParamsInto = function(assertionParams, pa
   } else {
     params.version = "2012.08.15";
   }
-}
+};
 
 var serializeAssertionParamsInto = function(assertionParams, params) {
   version.dispatchOnDataFormatVersion(SERIALIZER, 'serializeAssertionParamsInto', version.getDataFormatVersion(), assertionParams, params);
@@ -56,7 +56,7 @@ SERIALIZER._20120815_extractAssertionParamsFrom = function(params) {
 
 function extractAssertionParamsFrom(params) {
   return version.dispatchOnDataFormatVersion(SERIALIZER, 'extractAssertionParamsFrom', version.getDataFormatVersion(), params);
-};
+}
 
 
 exports.sign = function(payload, assertionParams, secretKey, cb) {
@@ -75,13 +75,16 @@ exports.verify = function(signedObject, publicKey, now, cb) {
 
     // check iat
     if (assertionParams.issuedAt) {
-      if (assertionParams.issuedAt.valueOf() > now.valueOf())
+      // Allow for 10 seconds of future clock skew
+      var futureSkew = 10 * 1000;
+      if (assertionParams.issuedAt.valueOf() > now.valueOf() + futureSkew)
         return cb("assertion issued later than verification date");
     }
 
     // check exp expiration
     if (assertionParams.expiresAt) {
-      if (assertionParams.expiresAt.valueOf() < now.valueOf())
+      var pastSkew = 120 * 1000;
+      if (assertionParams.expiresAt.valueOf() < now.valueOf() - pastSkew)
         return cb("assertion has expired");
     }
 

--- a/test/assertion-test.js
+++ b/test/assertion-test.js
@@ -17,7 +17,10 @@ var payload = {
 
 var now = new Date();
 var in_a_minute = new Date(now.getTime() + (60 * 1000));
-var a_second_ago = new Date(now.getTime() - 1000);
+// IssuedAt can be up to 10 seconds into the future
+var in_five_seconds = new Date(now.getTime() + (5 * 1000));
+// Expiration can be up to 120 seconds into the past
+var a_couple_seconds_ago = new Date(now.getTime() - 121 * 1000);
 
 testUtils.addBatches(suite, function(alg, keysize) {
   return {
@@ -78,14 +81,14 @@ testUtils.addBatches(suite, function(alg, keysize) {
             assert.isNotNull(assertionParams.expiresAt);
             assert.isNotNull(assertionParams.issuer);
             assert.isNotNull(assertionParams.audience);
-            assert.equal(assertionParams.audience, "https://example.com");            
+            assert.equal(assertionParams.audience, "https://example.com");
             assert.equal(assertionParams.expiresAt.valueOf(), in_a_minute.valueOf());
           }
         }
       },
       "sign an assertion that is already expired": {
         topic: function(kp) {
-          assertion.sign(payload, {issuer: "foo.com", expiresAt: a_second_ago,
+          assertion.sign(payload, {issuer: "foo.com", expiresAt: a_couple_seconds_ago,
                                   audience: "https://example.com"},
                          kp.secretKey,
                          this.callback);
@@ -111,13 +114,13 @@ testUtils.addBatches(suite, function(alg, keysize) {
             assert.isNotNull(payload.iss);
             assert.isNotNull(payload.aud);
             assert.equal(payload.aud, "https://example.com");
-            assert.equal(payload.exp, a_second_ago.valueOf());
+            assert.equal(payload.exp, a_couple_seconds_ago.valueOf());
           }
         },
-        "when verified with assertion": {
+        "when verified with assertion for large skew": {
           topic: function(signedObject, kp) {
             // now is Date()
-            assertion.verify(signedObject, kp.publicKey, new Date(), this.callback);
+            assertion.verify(signedObject, kp.publicKey, now, this.callback);
           },
           "does not verify": function(err, payload, assertionParams) {
             assert.isString(err);
@@ -125,6 +128,20 @@ testUtils.addBatches(suite, function(alg, keysize) {
           },
           "returns the right error message": function(err, payload, assertionParams) {
             assert.equal(err, "assertion has expired");
+          }
+        },
+        "when verified with assertion for small skew": {
+          topic: function(signedObject, kp) {
+            // signedObject expired at a_couple_seconds_ago
+            // Our now is 45 seconds after that, so we'll be within the
+            // 120 second tolerance
+            var now_skew = new Date(a_couple_seconds_ago.valueOf() + 45 * 1000);
+            assertion.verify(signedObject, kp.publicKey, now_skew, this.callback);
+          },
+          "verifies": function(err, payload, assertionParams) {
+            assert.isNull(err);
+            assert.isObject(payload);
+            assert.isObject(assertionParams);
           }
         }
       },
@@ -156,13 +173,13 @@ testUtils.addBatches(suite, function(alg, keysize) {
             assert.isNotNull(payload.iss);
             assert.isUndefined(payload.aud);
             assert.equal(payload.exp, in_a_minute.valueOf());
-            assert.equal(payload.iat, in_a_minute.valueOf());            
+            assert.equal(payload.iat, in_a_minute.valueOf());
           }
         },
-        "when verified with assertion": {
+        "when verified with assertion for large skew": {
           topic: function(signedObject, kp) {
             // now is Date()
-            assertion.verify(signedObject, kp.publicKey, new Date(), this.callback);
+            assertion.verify(signedObject, kp.publicKey, now, this.callback);
           },
           "does not verify": function(err, payload, assertionParams) {
             assert.isString(err);
@@ -170,6 +187,19 @@ testUtils.addBatches(suite, function(alg, keysize) {
           },
           "returns the right error message": function(err, payload, assertionParams) {
             assert.equal(err, "assertion issued later than verification date");
+          }
+        },
+        "can verify with assertion for small skew": {
+          topic: function(signedObject, kp) {
+            // signedObject issuedAt = in_a_minute
+            // Our now is 5 seconds before that
+            var now_skew = new Date(in_a_minute.valueOf() - 5 * 1000);
+            assertion.verify(signedObject, kp.publicKey, now_skew, this.callback);
+          },
+          "verifies fine": function(err, payload, assertionParams) {
+            assert.isNull(err);
+            assert.isObject(payload);
+            assert.isObject(assertionParams);
           }
         }
       }


### PR DESCRIPTION
- We'll tolerate 120 seconds off into the past
- We'll tolerate 10 seconds off into the future
