### PR TITLE
fix leaked global sPaddedMessageHex

### DIFF
--- a/libs/external/rsa-sign.js
+++ b/libs/external/rsa-sign.js
@@ -55,7 +55,7 @@ function _rsasign_getHexPaddedDigestInfoForString(s, keySize, hashAlg) {
   for (var i = 0; i < fLen; i += 2) {
     sMid += "ff";
   }
-  sPaddedMessageHex = sHead + sMid + sTail;
+  var sPaddedMessageHex = sHead + sMid + sTail;
   return sPaddedMessageHex;
 }
 


### PR DESCRIPTION
Mocha test runner was complaining about leaked globals, so I'm cleaning up.
