### PR TITLE
Add an extra field to the assertion for arbitrary application data

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,11 @@ Sometimes the JSON object to sign should be a standard assertion with pre-define
 
     // add special fields which will be encoded properly
     // payload cannot contain reserved fields
-    assertion.sign(payload, {issuer: "foo.com", expiresAt: new Date(new Date().valueOf() + 5000),
-                             issuedAt: new Date(), audience: "https://example.com"},
+    assertion.sign(payload, {issuer: "foo.com",
+                             expiresAt: new Date(new Date().valueOf() + 5000),
+                             issuedAt: new Date(),
+                             audience: "https://example.com"},
+                             extra: {someapp: {optional: "data"}}},
                       keypair.secretKey,
                       function(err, signedAssertion) {
        // a normal signedObject, much like above
@@ -118,10 +121,14 @@ Sometimes the JSON object to sign should be a standard assertion with pre-define
        var now = new Date();
        assertion.verify(signedObject, keypair.publicKey, now, function(err, payload, assertionParams) {
           // payload is the original payload
-          // assertionParams contains issuedAt, expiresAt as dates
-          // and issuer and audience as strings.
+          // assertionParams contains issuedAt, expiresAt as dates,
+          // issuer and audience as strings,
+          // and extra as an object.
        });
     });
+
+The `extra` field is optional.  It can be used by a user agent to embed
+application-specific data.  Its interpretation is left to the application.
 
 
 Certs

--- a/lib/assertion.js
+++ b/lib/assertion.js
@@ -14,6 +14,7 @@ SERIALIZER._LEGACY_serializeAssertionParamsInto = function(assertionParams, para
   params.exp = assertionParams.expiresAt ? assertionParams.expiresAt.valueOf() : undefined;
   params.iss = assertionParams.issuer;
   params.aud = assertionParams.audience;
+  params.ext = assertionParams.extra;
 };
 
 SERIALIZER._20120815_serializeAssertionParamsInto = function(assertionParams, params) {
@@ -37,11 +38,13 @@ SERIALIZER._LEGACY_extractAssertionParamsFrom = function(params) {
   assertionParams.expiresAt = utils.getDate(params.exp);
   assertionParams.issuer = params.iss;
   assertionParams.audience = params.aud;
+  assertionParams.extra = params.ext;
 
   delete params.iat;
   delete params.exp;
   delete params.iss;
   delete params.aud;
+  delete params.ext;
 
   return assertionParams;
 };

--- a/test/assertion-test.js
+++ b/test/assertion-test.js
@@ -83,6 +83,30 @@ testUtils.addBatches(suite, function(alg, keysize) {
           }
         }
       },
+      "sign an assertion with extra data": {
+        topic: function(kp) {
+          assertion.sign(payload, {issuer: "foo.com", expiresAt: in_a_minute,
+                                   audience: "https://example.com",
+                                   extra: {webrtc: {fingerprint: "DE:AD:BE:EF"}}
+                                   },
+                         kp.secretKey,
+                         this.callback);
+        },
+        "when verified with assertion": {
+          topic: function(signedObject, kp) {
+            // now is Date()
+            assertion.verify(signedObject, kp.publicKey, now, this.callback);
+          },
+          "assertionparams is good": function(err, newPayload, assertionParams) {
+            assert.isNotNull(assertionParams.expiresAt);
+            assert.isNotNull(assertionParams.issuer);
+            assert.isNotNull(assertionParams.audience);
+            assert.equal(assertionParams.audience, "https://example.com");
+            assert.equal(assertionParams.expiresAt.valueOf(), in_a_minute.valueOf());
+            assert.equal(assertionParams.extra.webrtc.fingerprint, "DE:AD:BE:EF");
+          }
+        }
+      },
       "sign an assertion that is already expired": {
         topic: function(kp) {
           assertion.sign(payload, {issuer: "foo.com", expiresAt: a_second_ago,


### PR DESCRIPTION
For webrtc, we are presented with the need to embed an extra field in the assertion, namely the fingerprint of the peer connection key.

See [Section 5.6.5.2.2 of the security architecture draft spec](https://tools.ietf.org/html/draft-ietf-rtcweb-security-arch-06#section-5.6.5.2.2).

I propose we add a field to the assertion called `extra` which can contain an arbitrary object.  To provide a namespace and avoid possible collisions, the first field of the `extra` object should be the name of the application from or to which the user agent is declaring the assertion.  The meaning of the contents of the `extra` param is up to the application to interpret.  It can be ignored by applications that are not expecting it.

So for the webrtc key fingerprint case, the `extra` param might be: `extra.webrtc.fingerprint = "DE:AD:BE:EF"`.
