### PR TITLE
switch bigint dependency to bignum

### DIFF
--- a/libs/bigint-patch.js
+++ b/libs/bigint-patch.js
@@ -5,7 +5,7 @@ var nativeBigInteger = null;
 // patches to bigint to use native node code if possible
 try {
   // if we can get node-bigint, we continue. If not, blarg.
-  var bigint = require("bigint");
+  var bigint = require("bignum");
   var crypto = require("crypto");
 
   // trying to mimick Tom Wu's constructor
@@ -79,7 +79,7 @@ try {
       return this._bigint.cmp(other._bigint);
     },
     toString: function(base) {
-      return this._bigint.toString(base || 10);
+      return this._bigint.toString(base || 10).replace(/^0/, '');
     },
     gcd: function(other) {
       return BigInteger._from_bigint(this._bigint.gcd(other._bigint));

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "uglify-js": "1.0.6"
   }
   , "optionalDependencies": {
-    "bigint": "0.4.2"
+    "bignum": "0.6.1"
   }
   , "scripts": {
     "postinstall": "node ./scripts/bundle.js",


### PR DESCRIPTION
`bigint` and `bignum` have one minor difference in their implementation of `toString(16)`. `bignum` pads to an even number of characters, while `bigint` does not. The difference causes several tests to fail. Instead of changing the behavior elsewhere this patch simply strips the leading `0` from the string if it's present.

see #61
