### PR TITLE
fix base64url decoding in jsbn BigInteger

### DIFF
--- a/libs/jsbn-patch.js
+++ b/libs/jsbn-patch.js
@@ -5,5 +5,5 @@ BigInteger.prototype.toBase64 = function() {
 };
 
 BigInteger.fromBase64 = function(str) {
-  return new BigInteger(b64tohex(str), 16);
+  return new BigInteger(new Buffer(str, 'base64').toString('hex'), 16);
 };


### PR DESCRIPTION
The `b64tohex` function doesn't handle base64url encoding correctly,
whereas the `Buffer` `base64` codec handles it fine.  The bigint
patch uses `Buffer` whereas the jsbn patch uses `b64tohex`, leading
to inconsistent behaviour between the native and pure-js BigInteger
implementations.

Since more recent versions of the JOSE specifications use base64url
encodings of key parameters, it is important to handle base64url
correctly.  Therefore use `Buffer` rather than `b64tohex` in the
jsbn wrapper.
