### PR TITLE
Base64url decode

### DIFF
--- a/libs/jsbn-patch.js
+++ b/libs/jsbn-patch.js
@@ -4,6 +4,8 @@ BigInteger.prototype.toBase64 = function() {
   return hex2b64(this.toString(16));
 };
 
-BigInteger.fromBase64 = function(str) {
+BigInteger.fromBase64 = function(_str) {
+  // check for urlencoded b64
+  var str = _str.replace(/-/g, '+').replace(/_/g, '/');
   return new BigInteger(b64tohex(str), 16);
 };


### PR DESCRIPTION
new formats include the numbers being base64 encoded, likely to save
bytes. They were being created with .toBase64URL(), which also
url-encodes them. Seems sensible.

On deserializing, the numbers are run through fromBase64(). If native
bigint exists, then fromBase64 is replaced to use Buffer(n, 'base64'),
which correctly url decodes it as well. If it doesn't exist, like on
windows or in the browser, then window.atob is used. It doesn't know
about urlencoded values.

This patch urldecodes the string before passing it to window.atob.
