### PR TITLE
tolerate configurable amount of clock skew

### DIFF
--- a/lib/assertion.js
+++ b/lib/assertion.js
@@ -55,13 +55,16 @@ exports.verify = function(signedObject, publicKey, now, cb) {
 
     // check iat
     if (assertionParams.issuedAt) {
-      if (assertionParams.issuedAt.valueOf() > now.valueOf())
+      // Allow for 10 seconds of future clock skew
+      var futureSkew = 10 * 1000;
+      if (assertionParams.issuedAt.valueOf() > now.valueOf() + futureSkew)
         return cb(new VerificationError("issued later than verification date"));
     }
 
     // check exp expiration
     if (assertionParams.expiresAt) {
-      if (assertionParams.expiresAt.valueOf() < now.valueOf()) {
+      var pastSkew = 120 * 1000;
+      if (assertionParams.expiresAt.valueOf() < now.valueOf() - pastSkew) {
         return cb(new VerificationError("expired"));
       }
     }

--- a/lib/assertion.js
+++ b/lib/assertion.js
@@ -42,7 +42,23 @@ exports.sign = function(payload, assertionParams, secretKey, cb) {
   jwcrypto.sign(allParams, secretKey, cb);
 };
 
-exports.verify = function(signedObject, publicKey, now, cb) {
+exports.verify = function(signedObject, publicKey, now, options, cb) {
+  // by default, allow the issuer's clock to be up to 10 seconds ahead of
+  // ours, or up to 120 seconds behind. Callers can control this by passing
+  // in other values (in seconds).
+  var tolerateOld = 120 * 1000;
+  var tolerateNew = 10 * 1000;
+  if (typeof options === 'function') {
+    cb = options;
+  } else {
+    if (options && options.tolerateOld) {
+      tolerateOld = options.tolerateOld * 1000;
+    }
+    if (options && options.tolerateNew) {
+      tolerateNew = options.tolerateNew * 1000;
+    }
+  }
+
   jwcrypto.verify(signedObject, publicKey, function(err, payload) {
     if (err) return cb(err);
 
@@ -55,16 +71,14 @@ exports.verify = function(signedObject, publicKey, now, cb) {
 
     // check iat
     if (assertionParams.issuedAt) {
-      // Allow for 10 seconds of future clock skew
-      var futureSkew = 10 * 1000;
-      if (assertionParams.issuedAt.valueOf() > now.valueOf() + futureSkew)
+      if (assertionParams.issuedAt.valueOf() > now.valueOf() + tolerateNew) {
         return cb(new VerificationError("issued later than verification date"));
+      }
     }
 
     // check exp expiration
     if (assertionParams.expiresAt) {
-      var pastSkew = 120 * 1000;
-      if (assertionParams.expiresAt.valueOf() < now.valueOf() - pastSkew) {
+      if (assertionParams.expiresAt.valueOf() < now.valueOf() - tolerateOld) {
         return cb(new VerificationError("expired"));
       }
     }

--- a/test/assertion-test.js
+++ b/test/assertion-test.js
@@ -17,7 +17,7 @@ var payload = {
 
 var now = new Date();
 var in_a_minute = new Date(now.getTime() + (60 * 1000));
-// IssuedAt can be up to 10 seconds into the future
+// IssuedAt can be up to 10 seconds into the future, by default
 var in_five_seconds = new Date(now.getTime() + (5 * 1000));
 // Expiration can be up to 120 seconds into the past
 var a_couple_seconds_ago = new Date(now.getTime() - 121 * 1000);


### PR DESCRIPTION
This is not yet complete, but should be a good direction to go for adding tolerance of clock skew. It still needs a way to get the 'options' value into the `verify()` call, and some tests.

@seanmonstar, is the way I'm testing for function-ness of `cb` the right way to do it? I'm still a bit fuzzy on this crazy argument polymorphism that the JS world seems to think is normal :).

refs #58 and #59