### PR TITLE
switch bigint dependency to bignum

### DIFF
--- a/libs/bigint-patch.js
+++ b/libs/bigint-patch.js
@@ -5,7 +5,7 @@ var nativeBigInteger = null;
 // patches to bigint to use native node code if possible
 try {
   // if we can get node-bigint, we continue. If not, blarg.
-  var bigint = require("bigint");
+  var bigint = require("bignum");
   var crypto = require("crypto");
 
   // trying to mimick Tom Wu's constructor
@@ -79,7 +79,7 @@ try {
       return this._bigint.cmp(other._bigint);
     },
     toString: function(base) {
-      return this._bigint.toString(base || 10);
+      return this._bigint.toString(base || 10).replace(/^0/, '');
     },
     gcd: function(other) {
       return BigInteger._from_bigint(this._bigint.gcd(other._bigint));

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">= 0.8.11"
   },
   "optionalDependencies": {
-    "bigint": "0.4.2"
+    "bignum": "0.9.2"
   },
   "scripts": {
     "postinstall": "node ./scripts/bundle.js",


### PR DESCRIPTION
#69 back from the grave in order to support node v0.12 and iojs.