### PR TITLE
feat(cert): Support checking multiple root pubkeys when verifying a bundle.

### DIFF
--- a/lib/cert.js
+++ b/lib/cert.js
@@ -8,6 +8,7 @@ var error = require("./error");
 var utils = require("./utils");
 var delay = utils.delay;
 var MalformedError = error.MalformedError;
+var VerificationError = error.VerificationError;
 
 var serializeCertParamsInto = function(certParams, params) {
   params['public-key'] = certParams.publicKey.toSimpleObject();
@@ -109,16 +110,34 @@ var verifyChain = function(certs, now, getRoot, cb) {
     });
   }
 
-  // get the root public key
-  getRoot(rootIssuer, function(err, rootPK) {
+  // Get the root public key to start the chain.
+  // There may be several candidate keys, in which case
+  // we try each until we find one that works.
+  getRoot(rootIssuer, function(err, rootPKs) {
     if (err) return delay(cb)(err);
 
-    verifyCert(0, rootPK, [], function(err, certParamsArray /* , lastPK */) {
-      if (err) return cb(err);
+    if (!Array.isArray(rootPKs)) {
+      rootPKs = [rootPKs];
+    } else if (rootPKs.length === 0) {
+      return delay(cb)(new VerificationError('no public keys found for root issuer'));
+    }
 
-      // we're done
-      cb(null, certParamsArray);
-    });
+    function tryRootPK(kIdx) {
+      verifyCert(0, rootPKs[kIdx], [], function(err, certParamsArray /* , lastPK */) {
+        if (err) {
+          // try the next key, or error out if we've tried them all
+          kIdx++;
+          if (kIdx >= rootPKs.length) {
+            return cb(err);
+          }
+          return tryRootPK(kIdx);
+        } else {
+          // we're done
+          cb(null, certParamsArray);
+        }
+      });
+    }
+    tryRootPK(0);
   });
 };
 

--- a/test/cert-test.js
+++ b/test/cert-test.js
@@ -183,7 +183,7 @@ testUtils.addBatches(suite, function(alg, keysize) {
                             function(issuer, next) {
                               if (issuer == "root.com")
                                 // wrong public key!
-                                next(stuff.userPK);
+                                next(null, stuff.userPK);
                               else
                                 next(null);
                             },
@@ -201,7 +201,7 @@ testUtils.addBatches(suite, function(alg, keysize) {
                             function(issuer, next) {
                               if (issuer == "root.com")
                                 // wrong public key!
-                                next(stuff.userPK);
+                                next(null, stuff.userPK);
                               else
                                 next(null);
                             },
@@ -212,7 +212,80 @@ testUtils.addBatches(suite, function(alg, keysize) {
           assert.isNotNull(err);
           assert.isUndefined(certParamsArray);
         }
-      }
+      },
+      "multi-key root - just chain": {
+        topic: function(stuff) {
+          cert.verifyChain(stuff.certs, new Date(),
+                            function(issuer, next) {
+                              if (issuer == "root.com")
+                                next(null, [stuff.userPK, stuff.rootPK]);
+                              else
+                                next(null);
+                            },
+                            this.callback
+                           );
+        },
+        "verifies": function(err, certParamsArray) {
+          assert.isNull(err);
+          assert.isArray(certParamsArray);
+        }
+      },
+      "multi-key root": {
+        topic: function(stuff) {
+          cert.verifyBundle(stuff.bundle, new Date(),
+                            function(issuer, next) {
+                              if (issuer == "root.com")
+                                next(null, [stuff.userPK, stuff.rootPK]);
+                              else
+                                next(null);
+                            },
+                            this.callback
+                           );
+        },
+        "verifies": function(err, certParamsArray, payload, assertionParams) {
+          assert.isNull(err);
+          assert.isArray(certParamsArray);
+          assert.isObject(payload);
+          assert.isObject(assertionParams);
+          assert.isNotNull(assertionParams.audience);
+        }
+      },
+      "multi-key improper root - just chain": {
+        topic: function(stuff) {
+          cert.verifyChain(stuff.certs, new Date(),
+                            function(issuer, next) {
+                              if (issuer == "root.com")
+                                // wrong public key!
+                                next(null, [stuff.userPK, stuff.userPK]);
+                              else
+                                next(null);
+                            },
+                            this.callback
+                           );
+        },
+        "does not verify": function(err, certParamsArray) {
+          assert.isNotNull(err);
+          assert.isUndefined(certParamsArray);
+        }
+      },
+      "multi-key improper root": {
+        topic: function(stuff) {
+          cert.verifyBundle(stuff.bundle, new Date(),
+                            function(issuer, next) {
+                              if (issuer == "root.com")
+                                // wrong public key!
+                                next(null, [stuff.userPK, stuff.userPK]);
+                              else
+                                next(null);
+                            },
+                            this.callback
+                           );
+        },
+        "does not verify": function(err, certParamsArray, payload, assertionParams) {
+          assert.isNotNull(err);
+          assert.isUndefined(certParamsArray);
+        }
+      },
     },
     "null issued_at" : {
       topic: function() {


### PR DESCRIPTION
This change provides the ability to verify a bundle against multiple candidate public keys, succeeding if any one of them verifies the signature.  It will allow IdPs to publish multiple active keys during e.g. a key rotation event.  It's backwards-compatible with existing callers that return only a single pubkey.

As a bonus it fixes an issue with two of the existing tests, which were returning an error as expected, but the error was for the wrong reason.

Will be used in support of https://github.com/mozilla/browserid-verifier/issues/69

@vladikoff r?