### PR TITLE
fix(deps): Update deps to resolve NSP warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "browserid-crypto",
   "version": "0.8.0",
   "dependencies": {
-    "browserify": "5.9.1",
-    "http-browserify": "1.4.1",
-    "vows": "0.7.0",
+    "browserify": "13.1.0",
+    "http-browserify": "1.7.0",
+    "vows-without-nsp-warnings": "0.10.0",
     "optimist": "0.6.1",
-    "uglify-js": "2.4.15"
+    "uglify-js": "2.7.3"
   },
   "devDependencies": {
-    "jshint": "~2.5.2",
+    "jshint": "~2.9.3",
     "walk": "~2.2.1"
   },
   "engines": {

--- a/test/assertion-test.js
+++ b/test/assertion-test.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var vows = require("vows"),
+var vows = require("./vows"),
     assert = require("assert"),
     jwcrypto = require("../index"),
     assertion = jwcrypto.assertion,

--- a/test/cert-test.js
+++ b/test/cert-test.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var vows = require("vows"),
+var vows = require("./vows"),
     assert = require("assert"),
     jwcrypto = require("../index"),
     assertion = jwcrypto.assertion,

--- a/test/format-test.js
+++ b/test/format-test.js
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var
-vows = require('vows'),
+vows = require('./vows'),
 assert = require('assert'),
 path = require('path'),
 jwcrypto = require('../index'),

--- a/test/jshint-test.js
+++ b/test/jshint-test.js
@@ -4,7 +4,7 @@
 
 // jshinting (syntax checking) of the source
 
-const vows = require("vows"),
+const vows = require("./vows"),
       fs = require('fs'),
       path = require('path'),
       jshint = require('jshint').JSHINT,

--- a/test/jwcrypto-test.js
+++ b/test/jwcrypto-test.js
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var
-vows = require('vows'),
+vows = require('./vows'),
 assert = require('assert'),
 path = require('path'),
 jwcrypto = require('../index'),

--- a/test/rng-test.js
+++ b/test/rng-test.js
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var
-vows = require('vows'),
+vows = require('./vows'),
 assert = require('assert'),
 rng = require('../lib/rng');
 

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var vows = require("vows"),
+var vows = require("./vows"),
     assert = require("assert"),
     utils = require("../lib/utils");
 

--- a/test/vectors-test.js
+++ b/test/vectors-test.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var vows = require("vows"),
+var vows = require("./vows"),
     assert = require("assert"),
     jwcrypto = require("../index");
 

--- a/test/vows.js
+++ b/test/vows.js
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = require('vows-without-nsp-warnings');


### PR DESCRIPTION
Unfortunately the latest release version of `vows` is two years old and has vulnerable dependencies.  I worked around this by publishing a renamed version with updated deps.

@jrgm r?