### PR TITLE
fix(deps): Update bignum dependency to build on node10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 
 node_js:
- - "0.10"
- - "0.12"
- - "4"
- - "6"
+ - "8"
+ - "10"
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">= 0.10"
   },
   "optionalDependencies": {
-    "bignum": "0.12.5"
+    "bignum": "~0.13.0"
   },
   "scripts": {
     "postinstall": "node ./scripts/bundle.js",


### PR DESCRIPTION
In service of https://github.com/mozilla/browserid-verifier/issues/113; @vladikoff r?