### PR TITLE
Fix minified file generation in bundle script

### DIFF
--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -38,5 +38,5 @@ bundle.bundle(function(err, buf) {
   fs.writeFileSync(OUTPUT, bundleOutput);
 
   // and now make it all ugly
-  fs.writeFileSync(OUTPUT_MIN, uglify(bundleOutput, { fromString: true }));
+  fs.writeFileSync(OUTPUT_MIN, uglify(bundleOutput, { fromString: true }).code);
 });


### PR DESCRIPTION
Currently `bidbundle-min.js` contains `[object Object]` instead of the minified code.

This is because UglifyJS returns an object with the actual code in the `code` property.

In Node.js 14+, `fs.writeFileSync` doesn't write `[object Object]` anymore, and instead throws the following exception:

    TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Object

Since `./scripts/bundle.js` is run on npm postinstall, and it throws with the error above, this breaks `npm install browserid-crypto` on Node.js 14+, making it impossible to install the package.

This commit fixes the build by using the `code` property of the UglifyJS output to write the actual code to the `bidbundle-min.js` and make the package installable again.