### PR TITLE
Replace `new Buffer` with `Buffer.from` to remove deprecation warning

### DIFF
--- a/libs/bigint-patch.js
+++ b/libs/bigint-patch.js
@@ -93,7 +93,7 @@ try {
   };
 
   BigInteger.fromBase64 = function(b64_string) {
-    var bi = bigint.fromBuffer(new Buffer(b64_string, 'base64'));
+    var bi = bigint.fromBuffer(Buffer.from(b64_string, 'base64'));
     return BigInteger._from_bigint(bi);
   };
 

--- a/libs/preliminaries.js
+++ b/libs/preliminaries.js
@@ -6,10 +6,10 @@ if (typeof(OVERRIDE) == "undefined") {
 
   var window = {
     atob: function(str) {
-      return new Buffer(str, 'base64').toString('utf-8');
+      return Buffer.from(str, 'base64').toString('utf-8');
     },
     btoa: function(str) {
-      return new Buffer(str).toString('base64');
+      return Buffer.from(str).toString('base64');
     }
   };
 

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -17,7 +17,7 @@ var MINIMAL_OUTPUT = path.join(LIBS_DIR, './minimal.js');
 var appendFileSync = fs.appendFileSync || function(path, data) {
   var fd = fs.openSync(path, 'a');
   if (!Buffer.isBuffer(data)) {
-    data = new Buffer('' + data, 'utf8');
+    data = Buffer.from('' + data, 'utf8');
   }
   var written = 0;
   var position = null;


### PR DESCRIPTION
As per Node.js porting nodes, the `Buffer()` and `new Buffer()` constructors have security concerns.

> The `Buffer()` and `new Buffer()` constructors are not recommended for use due to security and usability concerns. Please use the new `Buffer.alloc()`, `Buffer.allocUnsafe()`, or `Buffer.from()` construction methods instead.

See <https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/>.

Here's their migration recommendation:

> For `new Buffer(string)` (or `new Buffer(string, encoding)`), replace it with `Buffer.from(string)` (or `Buffer.from(string, encoding)`).

This PR implements this migration so that Node.js doesn't show a warning anymore when using the library.